### PR TITLE
Filter out unwanted props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,23 @@ class ImageComponent extends AppComponent {
       backgroundRepeat: 'no-repeat',
       backgroundSize: 'cover',
     });
-    return <div className="node image" {...elemProps} />;
+      //Filter out unwanted props
+      const {
+          componentData,
+          isDragging,
+          canAcceptDrop,
+          hasChildren,
+          getComponent,
+          getComponentType,
+          getComponentPropertyData,
+          setPropertyData,
+          moveUI,
+          moveInto,
+          setHoverObject,
+          hoverObject,
+          ...props
+      } = elemProps;
+    return <div className="node image" {...props} />;
   }
 }
 


### PR DESCRIPTION
Clears all console errors when you use `Flow-App-Component-Image` by removing all unwanted props which do not meet the naming convention of React props on HTML elements